### PR TITLE
Export the plugin as default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function getNext(color, customize, context) {
   return c;
 }
 
-export default {
+var autocolorPlugin = {
   id: 'autocolors',
   beforeUpdate(chart, args, options) {
     const {mode = 'dataset', enabled = true, customize, repeat} = options;
@@ -97,3 +97,5 @@ function labelMode(chart, gen, customize) {
     setColors(dataset, c.background, c.border);
   }
 }
+
+export {autocolorPlugin as default};

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -7,12 +7,12 @@ declare module 'chart.js' {
   }
 }
 
-interface ColorsDescriptor {
+export interface ColorsDescriptor {
   background: string
   border: string
 }
 
-interface AutocolorsOptions {
+export interface AutocolorsOptions {
   enabled?: boolean,
   mode?: 'dataset' | 'data' | 'label',
   offset?: number,
@@ -20,9 +20,15 @@ interface AutocolorsOptions {
   customize?: (ctx: AutocolorsContext, options: AutocolorsOptions) => ColorsDescriptor
 }
 
-interface AutocolorsContext {
+export interface AutocolorsContext {
   chart: Chart
   colors: ColorsDescriptor
   dataIndex?: number
   datasetIndex: number
 }
+
+/**
+ * Exports the plugin class as default
+ */
+// eslint-disable-next-line @typescript-eslint/no-use-before-define
+export { autocolorPlugin as default };


### PR DESCRIPTION
To support

```
import autocolor from "chartjs-plugin-autocolors";

Chart.register(autocolor);

```
in a Typescript file.