### PR TITLE
docs: replace broken CI badge and group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,16 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
-
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 *Automatic color generation for [Chart.js](https://www.chartjs.org)*
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/kurkle/chartjs-plugin-autocolors/ci.yml)
+[![npm](https://img.shields.io/npm/v/chartjs-plugin-autocolors.svg)](https://www.npmjs.com/package/chartjs-plugin-autocolors)
+[![release](https://img.shields.io/github/release/kurkle/chartjs-plugin-autocolors.svg?style=flat-square)](https://github.com/kurkle/chartjs-plugin-autocolors/releases/latest)
+![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-plugin-autocolors.svg)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-autocolors&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-autocolors)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-autocolors&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-autocolors)
+![GitHub](https://img.shields.io/github/license/kurkle/chartjs-plugin-autocolors.svg)
 
 The generation is based on Janus Troelsen's answer at [Stack Overflow](https://stackoverflow.com/a/13781114/10359775).
 


### PR DESCRIPTION
## Summary
- The README's only badge pointed at `ci.yml`, which #243 removed when CI moved to the shared `pr-ci.yml`/`main-ci.yml` workflows — the badge has been broken since that PR. Replaced it with the standard kurkle-repo badge row: npm version, GitHub release, bundlephobia min size, Sonar quality gate, Sonar coverage, GitHub license (in that order). No documentation badge — this package has no docs site. Used the Sonar project key from `sonar-project.properties` (`kurkle_chartjs-plugin-autocolors`) rather than guessing it.
- `.github/dependabot.yml`: added dependency grouping (dev dependencies grouped for npm, all actions grouped for github-actions) and dropped the stale boilerplate comments, matching the other kurkle repos.

## Depends on
Stacked on #243 (shared CI workflow) since that PR is what broke the badge in the first place.

## Test plan
- [x] `npm run lint` passes (same 4 pre-existing warnings, unrelated to this change)
- [x] `npm test`, `npm run typecheck`, `npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)