### PR TITLE
ci: pass SONAR_TOKEN explicitly and scan workflow files

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -17,7 +17,8 @@ jobs:
       coverage-paths: |
         coverage/chrome/lcov.info
         coverage/firefox/lcov.info
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,4 +16,5 @@ jobs:
       coverage-paths: |
         coverage/chrome/lcov.info
         coverage/firefox/lcov.info
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,14 @@ sonar.organization=kurkle
 sonar.projectName=chartjs-plugin-autocolors
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=src/
+sonar.sources=src/,.github/workflows
 sonar.tests=test/
 
 sonar.javascript.lcov.reportPaths=coverage/chrome/lcov.info,coverage/firefox/lcov.info
+
+# The floating v1 tag is deliberate: it is how a fix in kurkle/configs reaches
+# every repository without a pull request in each one. Pinning a commit SHA
+# would defeat that mechanism.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/*.yml


### PR DESCRIPTION
## Summary
- `kurkle/configs` `v1` (now at 1.3.0) declares `SONAR_TOKEN` as a named `workflow_call` secret, so `pr-ci.yml` and `main-ci.yml` no longer need the broad `secrets: inherit` — pass just `SONAR_TOKEN`. `GITHUB_TOKEN` needs no passing; it's always available to the calling workflow.
- Add `.github/workflows` to `sonar.sources` so the workflow files themselves get analyzed (previously only `src/` was scanned).
- Ignore `githubactions:S7637` (unpinned action version) specifically for `.github/workflows/*.yml`, with a comment explaining why: the floating `v1` tag on the shared workflow is deliberate — it's how a fix in `kurkle/configs` reaches every repository without a PR in each one, and pinning a commit SHA would defeat that mechanism.

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run build`, `npm test` all pass locally
- [ ] Confirm this PR's own Sonar run analyzes the workflow files and neither S7635 nor S7637 are reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)