### PR TITLE
fix(types): make types/tests/tsconfig.json compatible with TypeScript 7

### DIFF
--- a/types/tests/tsconfig.json
+++ b/types/tests/tsconfig.json
@@ -5,11 +5,10 @@
     "alwaysStrict": true,
 
     /* Modules */
-    "baseUrl": ".",
     "checkJs": true,
     "lib": ["es2018", "DOM"],
     "module": "ES6",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
 
     /* Emit */
     "noEmit": true,


### PR DESCRIPTION
## Summary
The dependabot dev-dependencies group update (#245) fails at the typecheck step because TypeScript 7 removed two options this config used:

```
types/tests/tsconfig.json(8,5): error TS5102: Option 'baseUrl' has been removed.
types/tests/tsconfig.json(12,25): error TS5108: Option 'moduleResolution=node10' has been removed.
```

- Removed `baseUrl`. It served no purpose here — every import in `types/tests/` is either a bare package specifier resolved through `node_modules` (`chart.js`, `@kurkle/color`) or a relative `include` path, neither of which depends on `baseUrl`. No `paths` mapping was needed to replace it.
- Changed `moduleResolution` from `"Node"` (the removed `node10` alias) to `"Bundler"`, matching what `chartjs-chart-matrix`, `chartjs-chart-sankey`, and `chartjs-chart-treemap` already use for their equivalent type-test configs.

Unlike the other kurkle repos that block on TypeScript 7 for other reasons (typedoc, `@astrojs/check`), this repo has no such blocker, so this is a real fix rather than a workaround.

## Test plan
- [x] `npm run typecheck` passes with the pinned TypeScript (5.9.3, current lockfile)
- [x] `npm run typecheck` passes with TypeScript 7.0.2 (the dependabot group's target), installed temporarily with `npm install --no-save` and reverted with `npm ci` before committing — lockfile is unchanged
- [x] `npm run lint`, `npm run build`, `npm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)