### PR TITLE
ci: ignore lifecycle scripts when installing for release

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
Dependency lifecycle scripts (preinstall/install/postinstall) are a common npm supply-chain attack vector. The release job installed with plain `npm clean-install`, running any lifecycle scripts declared by the dependency tree with no benefit here.

`.github/workflows/main-ci.yml` line 44: `npm clean-install` → `npm clean-install --ignore-scripts`.

This repo's dependency tree has exactly one package with an install script — `fsevents`, which is macOS-only (`os: ["darwin"]` in package-lock.json) and never installs on the Linux runner anyway — so the change has no functional risk here. Verified this directly rather than only trusting the cross-repo scan: scanned `package-lock.json` for `hasInstallScript` and confirmed fsevents is the only hit, then reproduced the release job's install + build steps locally (`npm clean-install --ignore-scripts && npm run build`) and got the expected `dist/` output.

`pr-ci.yml` has no `compressed-size` job (unlike some sibling repos), so there's nothing else to change there. The shared workflow's own defaults are untouched.

## Test plan
- [x] `npm clean-install --ignore-scripts` followed by `npm run build` locally reproduces the release job and produces correct dist output
- [x] `npm run lint`, `npm run typecheck`, `npm test` all pass (normal `npm ci`, unaffected by this change)
- [ ] Confirm this PR's own CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)