### PR TITLE
docs: wire Cloudflare Pages docs deploy into main-ci

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -50,3 +50,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx --no-install semantic-release
+
+      - name: Resolve released version
+        id: release-version
+        run: |
+          VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null | sed 's/^v//')
+          if [ -z "$VERSION" ]; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No release tag on HEAD, skipping Cloudflare Pages version update"
+            exit 0
+          fi
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved released version: $VERSION"
+
+      - name: Update Cloudflare Pages production docs version
+        if: steps.release-version.outputs.released == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
+        run: |
+          curl --fail --silent --show-error \
+            --request PATCH \
+            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --header 'Content-Type: application/json' \
+            --data @- <<EOF
+          {
+            "deployment_configs": {
+              "production": {
+                "env_vars": {
+                  "DOCS_VERSION": {
+                    "type": "plain_text",
+                    "value": "${DOCS_VERSION}"
+                  }
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Trigger Cloudflare Pages production deploy
+        if: steps.release-version.outputs.released == 'true'
+        env:
+          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
+        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary

Adds the Cloudflare Pages deploy wiring to `.github/workflows/main-ci.yml`, matching `chartjs-chart-sankey`'s `release` job (fetched via `gh api`, not from memory). Follow-up to the docs site in #249, which intentionally left CI wiring out of scope.

Two new steps run after `semantic-release`, both gated on `steps.release-version.outputs.released == 'true'`:

1. **Update Cloudflare Pages production docs version** — PATCHes the Cloudflare API to set the `DOCS_VERSION` production env var to the version that was just released.
2. **Trigger Cloudflare Pages production deploy** — POSTs to the deploy hook, so the next `astro build` picks up the new `DOCS_VERSION` (via `docs:version` → `docs/src/generated/version.js`, shown in the docs site's footer).

**This repo's `release` job had no way to know whether a release actually happened** — unlike sankey, it ran `semantic-release` directly with no step capturing the outcome. Without adding that too, the two new steps' `if:` condition could never be true and the deploy would never fire. So this PR also adds sankey's **"Resolve released version"** step (`id: release-version`), which checks whether HEAD got tagged and sets `released`/`version` outputs accordingly.

## Verification

- YAML validity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main-ci.yml'))"` → parses cleanly.
- Diffed against sankey's `main-ci.yml` (fetched via `gh api repos/kurkle/chartjs-chart-sankey/contents/.github/workflows/main-ci.yml`): the only difference in the entire file is the pre-existing `coverage-paths` block in the `shared-ci` job (this repo runs karma coverage for two browsers; unrelated to this change, not touched by it). The added Cloudflare/release-version block is byte-identical to sankey's.
- Confirmed the four secrets this workflow references (`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_PAGES_PROJECT`, `CLOUDFLARE_PAGES_DEPLOY_HOOK`) were already reported as present on this repo before starting.

## What this does NOT verify

- **No real deploy has been triggered or observed.** The gate (`released == 'true'`) only becomes true on an actual semantic-release run on `main`, i.e. the next real release after this merges. Until then, this is unexercised code — I'm not claiming it works end-to-end, only that it's structurally identical to sankey's already-deployed version and passes YAML validation.
- **This repo has no `NPM_TOKEN` secret**, unlike `chartjs-chart-matrix` and `chartjs-plugin-gradient` — it publishes via npm's OIDC trusted publishing instead. Confirmed, not speculated: `npm view chartjs-plugin-autocolors dist.attestations` shows a provenance attestation (`predicateType: https://slsa.dev/provenance/v1`) on the current `v0.4.1` release, which only trusted publishing produces, and the `release` job in the most recent Main CI run completed successfully with no npm token in scope.

## Scope

Only `.github/workflows/main-ci.yml`. README.md thinning is a separate, immediately-following PR, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
