### PR TITLE
docs: thin README to a quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
 # chartjs-plugin-autocolors
 
-*Automatic color generation for [Chart.js](https://www.chartjs.org)*
-
 [![npm](https://img.shields.io/npm/v/chartjs-plugin-autocolors.svg)](https://www.npmjs.com/package/chartjs-plugin-autocolors)
 [![release](https://img.shields.io/github/release/kurkle/chartjs-plugin-autocolors.svg?style=flat-square)](https://github.com/kurkle/chartjs-plugin-autocolors/releases/latest)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-plugin-autocolors.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-autocolors&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-autocolors)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-autocolors&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-autocolors)
+[![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-plugin-autocolors.pages.dev)
 ![GitHub](https://img.shields.io/github/license/kurkle/chartjs-plugin-autocolors.svg)
 
-The generation is based on Janus Troelsen's answer at [Stack Overflow](https://stackoverflow.com/a/13781114/10359775).
-
-This plugin requires Chart.js 3.0.0 or later. Could work with v2, but it is not supported.
-
-**NOTE** the plugin does not automatically register.
+[Chart.js](https://www.chartjs.org/) plugin that automatically assigns a color to each dataset, data point, or
+label — no more picking colors by hand or reusing the same few colors across every chart, for anyone already
+charting with Chart.js.
 
 ## Example
 
@@ -21,159 +17,60 @@ This plugin requires Chart.js 3.0.0 or later. Could work with v2, but it is not 
 
 ## Installation
 
-NPM:
-
 ```bash
-npm i --save chartjs-plugin-autocolors
+npm install chart.js chartjs-plugin-autocolors
 ```
 
-CDN:
+Or via CDN:
 
 ```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-autocolors"></script>
 ```
 
-## Usage
-
-### loading
-
-ESM
+## Quickstart
 
 ```js
+import { Chart, registerables } from 'chart.js';
 import autocolors from 'chartjs-plugin-autocolors';
-```
 
-CDN
+Chart.register(...registerables, autocolors);
 
-```js
-const autocolors = window['chartjs-plugin-autocolors'];
-```
-
-### Registering
-
-All charts
-
-```js
-Chart.register(autocolors);
-```
-
-Single chart
-
-```js
-const chart = new Chart(ctx, {
-  // ...
-  plugins: [
-    autocolors
-  ]
+new Chart(document.getElementById('chart'), {
+  type: 'bar',
+  data: {
+    labels: ['Q1', 'Q2', 'Q3', 'Q4'],
+    datasets: [
+      { label: 'Dataset 1', data: [12, 19, 8, 15] },
+      { label: 'Dataset 2', data: [6, 11, 14, 9] },
+    ],
+  },
 });
 ```
 
-### Disabling (when registered for all charts)
+See more integration options (script tag, other module loaders) in the [documentation](https://chartjs-plugin-autocolors.pages.dev/integration/).
 
-If registered globally, it might be desirable to disable the autocolors for some charts
+## Documentation
 
-```js
-const chart = new Chart(ctx, {
-  // ...
-  options: {
-    plugins: {
-      autocolors: {
-        enabled: false
-      }
-    }
-  }
-});
+You can find documentation for chartjs-plugin-autocolors at [https://chartjs-plugin-autocolors.pages.dev/](https://chartjs-plugin-autocolors.pages.dev/). Modes, customization, offset, repeat, and browser compatibility are all covered there, not in this README — this file stays a quickstart.
+
+## Development
+
+You first need to install node dependencies (requires [Node.js](https://nodejs.org/)):
+
+```bash
+> npm install
 ```
 
-### Mode
+The following commands will then be available from the repository root:
 
-**NOTE:** `'dataset'` mode does not work properly for **Pie / Doughnut** charts, so using `'data'` mode with those charts is advised.
-
-There are two modes, `'dataset'` (default) `'data'` and `'label'`
-
-- In `'dataset'` mode, a new color is picked for each dataset.
-- In `'data'` mode, an array of colors, equivalent to the length of data is provided for each dataset.
-- In `'label'` mode, color is picked for each different dataset label.
-
-```js
-const chart = new Chart(ctx, {
-  // ...
-  options: {
-    plugins: {
-      autocolors: {
-        mode: 'data'
-      }
-    }
-  }
-});
+```bash
+> npm run build        // build dist files
+> npm run autobuild     // build and watch for changes
+> npm test              // run all tests
+> npm run lint          // perform code linting
 ```
-
-### Customize
-
-A `customize` function can be provided to customize the generated colors.
-The function is expected to return object containing `background` and `border` properties,
-with values acceptable as colors by Chart.js.
-
-```js
-const lighten = (color, value) => Chart.helpers.color(color).lighten(value).rgbString();
-
-const chart = new Chart(ctx, {
-  // ...
-  options: {
-    plugins: {
-      autocolors: {
-        customize(context) {
-          const colors = context.colors;
-          return {
-            background: lighten(colors.background, 0.5),
-            border: lighten(colors.border, 0.5)
-          };
-        }
-      }
-    }
-  }
-});
-```
-
-### Offset
-
-`offset` option can be used to offset the color generation by a number of colors.
-
-```js
-const chart = new Chart(ctx, {
-  // ...
-  options: {
-    plugins: {
-      autocolors: {
-        offset: 5
-      }
-    }
-  }
-});
-```
-
-### Repeat
-
-Sometimes you might need to color multiple adjacent datasets with same color. The `repeat` option is for that use case.
-
-
-```js
-const chart = new Chart(ctx, {
-  // ...
-  options: {
-    plugins: {
-      autocolors: {
-        repeat: 2
-      }
-    }
-  }
-});
-```
-
-## Browser compatibility
-
-This plugin uses a generator function, so it is not compatible with Internet Explorer.
 
 ## License
 
-`chartjs-plugin-autocolors.js` is available under the [MIT license](https://github.com/kurkle/chartjs-plugin-autocolors/blob/main/LICENSE).
+chartjs-plugin-autocolors is available under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary

Thins the 174-line README down to the same structure `chartjs-chart-sankey`, `chartjs-chart-matrix`, and `chartjs-chart-treemap` already use, now that the docs site (#249) exists as the full reference: badges, one-paragraph description, Example, Installation, Quickstart, Documentation, Development, License.

## Content accounted for — checked against the built site, not from memory

Per instructions, every section removed from the old README was checked against the actual built site output (`dist/docs`, and for `usage`/`integration`/`index` also the live Cloudflare preview for #249) before deleting anything:

| Old README section | Where it lives now |
|---|---|
| loading (ESM/CDN) | `integration.mdx` — ESM, CDN sections |
| Registering (all charts / single chart) | `integration.mdx` — Registering section |
| Disabling | `integration.mdx` — Disabling section |
| Mode (incl. the Pie/Doughnut caveat) | `usage.mdx` — Mode section, same caveat wording |
| Customize | `usage.mdx` — Customize section |
| Offset | `usage.mdx` — Offset section |
| Repeat | `usage.mdx` — Repeat section |
| Browser compatibility | `integration.mdx` — Browser compatibility section |
| "does not automatically register" note | `index.mdx` |

**Nothing was found missing.** Unlike the equivalent sankey port (which turned up two options documented only in the README), every piece of this README's content already has a home on the site. Re-checked a second time after #249 merged, directly against the live production site (https://chartjs-plugin-autocolors.pages.dev) rather than the pre-merge preview — all 11 content items (the 9 above plus loading-ESM and loading-CDN, split out) still confirmed present.

## Badges — checked individually, not copied

| Badge | Checked how | Result |
|---|---|---|
| npm version | registry.npmjs.org API | `chartjs-plugin-autocolors@0.4.1` exists |
| GitHub release | GitHub API | `v0.4.1` release exists |
| Bundle size (bundlephobia) | fetched the badge | currently renders "rate limited by upstream service" — a known, already-accepted situation for this badge (not something to fix here), kept per existing project decision |
| SonarCloud quality gate | SonarCloud badge API | renders "quality gate: passed" |
| SonarCloud coverage | SonarCloud badge API | **renders "Measure has not been found"** — left out of the README; unlike the quality gate metric, this project has no coverage measure on SonarCloud |
| Documentation | static shields.io badge | always renders; the link (chartjs-plugin-autocolors.pages.dev) is now live — #249 merged and the site returns 200 |
| License | shields.io badge | renders |

(www.npmjs.com itself returns 403 to curl/scripted fetches regardless of user-agent — a known npmjs.com bot-block, not a dead link; the registry API confirms the package page is real.)

## Quickstart — run, not written from memory

```js
import { Chart, registerables } from 'chart.js';
import autocolors from 'chartjs-plugin-autocolors';

Chart.register(...registerables, autocolors);

new Chart(document.getElementById('chart'), {
  type: 'bar',
  data: {
    labels: ['Q1', 'Q2', 'Q3', 'Q4'],
    datasets: [
      { label: 'Dataset 1', data: [12, 19, 8, 15] },
      { label: 'Dataset 2', data: [6, 11, 14, 9] },
    ],
  },
});
```

Actually executed against the built `dist/chartjs-plugin-autocolors.esm.js`, rendered via `@napi-rs/canvas` (installed with `npm install --no-save`, reverted afterwards with `npm ci`; `package-lock.json`/`package.json` diff confirmed empty both before and after). Result: the two datasets get distinct, non-empty `backgroundColor`/`borderColor` values.

Also confirmed the `registerables` gotcha the docs samples' globals otherwise hide: the identical snippet with `Chart.register(autocolors)` alone (no `registerables`) throws `"bar" is not a registered controller` — so the README's snippet needed the full registration, unlike the site's samples which get it for free from `docs/chart-runtime.js`.

## Verification

- `npm test`: 14/14 (one run hit a transient Chrome karma disconnect unrelated to this README-only change — confirmed by an immediate retry passing clean; not caused by this PR, which touches no test-relevant files).
- Every badge/link URL fetched individually (see table above).
- Quickstart snippet executed in Node against the real built plugin, both the working and the intentionally-broken (no `registerables`) variant.

## Scope

Only `README.md`. Site content, icons, `main-ci.yml`, and the old `samples/*.html` files are untouched, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

