### PR TITLE
docs: point the gradient ecosystem link at its own docs site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,7 +75,7 @@ export default defineConfig({
             },
             {
               label: 'chartjs-plugin-gradient',
-              link: 'https://github.com/kurkle/chartjs-plugin-gradient',
+              link: 'https://chartjs-plugin-gradient.pages.dev/',
             },
           ],
           label: 'Ecosystem',


### PR DESCRIPTION
## Summary

`chartjs-plugin-gradient` got its own documentation site today. The Ecosystem sidebar section in `astro.config.mjs` still pointed at its GitHub repo, unlike `chartjs-chart-matrix`, `chartjs-chart-sankey`, and `chartjs-chart-treemap`, which already link to gradient's (and each other's) `pages.dev` sites.

One-line change:

| Before | After |
|---|---|
| `https://github.com/kurkle/chartjs-plugin-gradient` | `https://chartjs-plugin-gradient.pages.dev/` |

`Awesome Chart.js` stays on GitHub — it's a GitHub repo with no separate site, same as in the sibling repos' configs.

## Verification

- Fetched the new URL directly: `curl -sL -o /dev/null -w "%{http_code}" https://chartjs-plugin-gradient.pages.dev/` → `200`.
- `npm run docs` builds cleanly, same page count as before (9 pages: `/`, `/integration/`, `/usage/`, 5×`/samples/*`, `/404`).
- Checked the **rendered HTML**, not just the source: `grep -o 'href="[^"]*chartjs-plugin-gradient[^"]*"' dist/docs/index.html` → `href="https://chartjs-plugin-gradient.pages.dev/"`. Also checked a second built page (`dist/docs/samples/bar/index.html`) since the sidebar is shared across all pages — same result. Confirmed the other three Ecosystem links (matrix/sankey/treemap) are still intact and pointing at their own `pages.dev` sites in the same rendered output.
- `npm test`: 14/14.

## Scope

Checked the rest of the repo for other stale cross-repo links (README, `src/content/docs/**`) — found none; this Ecosystem block in `astro.config.mjs` is the only place that cross-links sibling repos. Only that one line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
