### PR TITLE
ci: move Cloudflare Pages docs deploy into configs' shared workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -28,6 +28,9 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    outputs:
+      released: ${{ steps.release-version.outputs.released }}
+      version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -64,36 +67,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved released version: $VERSION"
 
-      - name: Update Cloudflare Pages production docs version
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
-        run: |
-          curl --fail --silent --show-error \
-            --request PATCH \
-            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
-            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            --header 'Content-Type: application/json' \
-            --data @- <<EOF
-          {
-            "deployment_configs": {
-              "production": {
-                "env_vars": {
-                  "DOCS_VERSION": {
-                    "type": "plain_text",
-                    "value": "${DOCS_VERSION}"
-                  }
-                }
-              }
-            }
-          }
-          EOF
-
-      - name: Trigger Cloudflare Pages production deploy
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
-        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"
+  docs-deploy:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: kurkle/configs/.github/workflows/docs-deploy.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+      CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary

Replaces the two inline Cloudflare Pages steps added in #250 (`Update Cloudflare Pages production docs version`, `Trigger Cloudflare Pages production deploy`) with a call to `kurkle/configs`' new reusable workflow, `.github/workflows/docs-deploy.yml@v1`, per its README's ["Docs deploy workflow"](https://github.com/kurkle/configs/blob/main/README.md#docs-deploy-workflow) section (read from source via `gh api repos/kurkle/configs/contents/README.md`, not written from memory).

That ~40-line block was byte-identical copy-paste across five repos (confirmed when adding it here in #250 by diffing against `chartjs-chart-sankey`'s `main-ci.yml`); it's now an ~8-line call site.

**The `release` job itself does not move.** npm's trusted publishing binds the publisher identity to the exact workflow file that runs `npx semantic-release` (`main-ci.yml`) — moving that call into a called workflow would change the identity and break publishing. This matters especially for this repo: autocolors has **no `NPM_TOKEN` secret at all** (confirmed via `gh secret list` while working on #250); its release publishes entirely through npm trusted publishing, evidenced by the provenance attestation (`predicateType: https://slsa.dev/provenance/v1`) on the published `v0.4.1` package. Only the two Cloudflare steps move; nothing that touches npm does.

## Changes to `.github/workflows/main-ci.yml`

Three changes, per the configs README:

1. Job-level `outputs:` on `release` (`released`, `version`), since a reusable-workflow job can only depend on another job's *job* outputs, not step outputs from a job it isn't part of.
2. Removed the two Cloudflare steps. **`Resolve released version` (`id: release-version`) stays unchanged** — it reads the git tag and belongs with the release itself, not the deploy, per the README's explicit guidance.
3. New `docs-deploy` job: `needs: release`, gated on `needs.release.outputs.released == 'true'`, calling `kurkle/configs/.github/workflows/docs-deploy.yml@v1` with the four Cloudflare secrets passed explicitly (not `secrets: inherit`, matching the configs README's least-exposure reasoning — this repo in particular has no `NPM_TOKEN` to worry about leaking, but the principle is fleet-wide).

**99 → 80 lines** (14 insertions, 33 deletions).

## Verification

- Confirmed `v1` on `kurkle/configs` points at `main`'s current commit (`9bbe1031...`, matched via `git/refs/tags/v1` and `git/refs/heads/main`) and that `.github/workflows/docs-deploy.yml` exists at that ref.
- `actionlint .github/workflows/main-ci.yml` → clean, exit 0.
- YAML parsed with `python3 -c "import yaml; yaml.safe_load(...)"` — valid; `release.outputs` and the new `docs-deploy` job both structured as expected.
- `Resolve released version` (`id: release-version`) and the `Release` step running `npx --no-install semantic-release` are still in the same file, same `release` job — confirmed by reading the diff and the full file after editing.
- `npm test`: 14/14.
- `npm run docs`: still builds all 9 pages (workflow-only change, unrelated to the docs site itself, but ran it anyway since the repo's pre-commit hook always does).

## What this does NOT verify

- **No real deploy through the new shared workflow has happened yet.** `docs-deploy` only runs when `release` actually tags a version on `main`, i.e. the next real release after this merges. Whether `kurkle/configs/.github/workflows/docs-deploy.yml@v1` itself behaves correctly end-to-end (correct Cloudflare API calls, correct secret plumbing through `workflow_call`) can only be confirmed by watching that next release run — this PR only confirms the calling side is structured per the documented contract and passes static checks (`actionlint`, YAML parse).

## Scope

Only `.github/workflows/main-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
