### PR TITLE
fix(deps): widen @kurkle/color peer range and rebuild dist on prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "module": "dist/chartjs-plugin-autocolors.esm.js",
   "name": "chartjs-plugin-autocolors",
   "peerDependencies": {
-    "@kurkle/color": "^0.4.0 || ^0.5.0",
+    "@kurkle/color": ">=0.3.0",
     "chart.js": ">=2"
   },
   "repository": {
@@ -82,6 +82,7 @@
     "lint": "biome check",
     "predocs": "npm run docs:version",
     "predocs:dev": "npm run docs:version",
+    "prepack": "npm run build",
     "prepare": "git config core.hooksPath .githooks || true",
     "test": "cross-env NODE_ENV=test concurrently \"npm:test-*\"",
     "test-karma": "karma start ./karma.conf.cjs --no-auto-watch --single-run",


### PR DESCRIPTION
## Summary

Two packaging-only fixes bundled together because both require a release to take effect.

- **Widen the `@kurkle/color` peer range to `>=0.3.0`** (from `^0.4.0 || ^0.5.0`). `chart.js@4.5.1` itself declares `"@kurkle/color": "^0.3.0"`, so a typical consumer running `npm install chart.js chartjs-plugin-autocolors` currently ends up with **two copies** of `@kurkle/color` in `node_modules` (chart.js's nested `0.3.x` plus a separately hoisted `0.4`/`0.5`) instead of deduping onto the one chart.js already brings in. The plugin only imports `hsv2rgb` and `rgbString`, both present as named exports since `0.3.x`, so `>=0.3.0` is safe. `devDependencies`' `@kurkle/color` stays on `^0.5.1` since the UMD build bundles it in.
- **Add `"prepack": "npm run build"`.** `main-ci.yml` runs `npm run build` before `semantic-release`, so the published `dist/*.esm.js`/`.cjs`/`.min.js` banners currently read `v0.0.0-development` instead of the real version. `npm publish` runs `prepack` right before packing the tarball, after semantic-release has written the real version into `package.json`, so this rebuilds dist with the correct banner. This mirrors `chartjs-chart-sankey`, the only one of the sibling packages with a correct banner, whose `.releaserc.json` and CI phase order are identical to this repo's.

## Test plan

- [x] `npm run lint` — passes (pre-existing warnings only, unrelated to this change)
- [x] `npm test` — 14/14 karma specs pass (Chrome + Firefox)
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm run docs` — passes
- [x] `npm pack` the tarball, installed it alongside `chart.js` in a clean scratch project (`chart.js` first, then the tarball — the realistic order), `npm ls --all` shows a single deduped `@kurkle/color@0.3.4`. Confirmed the previous range still produces two copies (`0.3.4` nested + `0.5.1` hoisted) under the same install order.
- [x] Removed `dist/`, ran `npm pack`, and confirmed the `prepack` hook rebuilt `dist/*.esm.js`/`.cjs`/`.min.js` before the tarball was created (fresh mtimes, present in the tarball contents).
- [ ] Correct version banner in the published package — cannot be verified before merge, only visible after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)