### PR TITLE
docs: adopt astro-chartjs-editor 1.3.1, live offset control

### DIFF
--- a/docs/styles/starlight.css
+++ b/docs/styles/starlight.css
@@ -1,7 +1,15 @@
 :root {
   --sl-content-width: 52rem;
+  --sl-text-h1: 2rem;
+  --sl-text-h2: 1.5rem;
+  --sl-text-h3: 1.25rem;
+  --sl-text-h4: 1.125rem;
 }
 
 .sl-markdown-content img {
   border-radius: 0.5rem;
+}
+
+.content-panel {
+  padding-block: 1rem;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/mdx": "^8.0.0",
         "@astrojs/starlight": "^0.42.0",
         "@biomejs/biome": "^2.5.12",
-        "@kurkle/astro-chartjs-editor": "^1.0.0",
+        "@kurkle/astro-chartjs-editor": "^1.3.1",
         "@kurkle/color": "^0.5.1",
         "@kurkle/configs": "^1.5.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -2462,15 +2462,20 @@
       }
     },
     "node_modules/@kurkle/astro-chartjs-editor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@kurkle/astro-chartjs-editor/-/astro-chartjs-editor-1.0.0.tgz",
-      "integrity": "sha512-/KBCKYV9+OmQrKWRz/n2+q+rAahGnw5TddFfAa3Z/VwXpL7NtMPDOsnejZVsI9sogxKOwD1U2K5g8H1TlwIbuA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@kurkle/astro-chartjs-editor/-/astro-chartjs-editor-1.3.1.tgz",
+      "integrity": "sha512-76QYNJ8d+ZSq2PeuLVEwGmRCDgijKwBU3aKKrd/JLd7VOO5z1Sd67rJC3NMVAatfK6a6c2m4Rxvw7A5GZBaHEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/state": "^6.7.4",
         "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.43.11",
         "codemirror": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
         "astro": "^5.0.0 || ^6.0.0 || ^7.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@astrojs/mdx": "^8.0.0",
     "@astrojs/starlight": "^0.42.0",
     "@biomejs/biome": "^2.5.12",
-    "@kurkle/astro-chartjs-editor": "^1.0.0",
+    "@kurkle/astro-chartjs-editor": "^1.3.1",
     "@kurkle/color": "^0.5.1",
     "@kurkle/configs": "^1.5.1",
     "@rollup/plugin-node-resolve": "^16.0.0",

--- a/src/content/docs/samples/customize.md
+++ b/src/content/docs/samples/customize.md
@@ -18,39 +18,35 @@ for (let i = 1; i <= 20; i++) {
 const data = { labels, datasets }
 // </block:data>
 
-// <block:options:2>
+// <block:config:0>
 const lighten = (color, value) => helpers.color(color).lighten(value).rgbString()
 
-const options = {
-  elements: {
-    bar: {
-      borderWidth: 2,
-    },
-  },
-  hover: {
-    mode: 'nearest',
-    intersect: true,
-  },
-  plugins: {
-    autocolors: {
-      mode: 'dataset',
-      customize(context) {
-        const colors = context.colors
-        return {
-          background: lighten(colors.background, 0.5),
-          border: lighten(colors.border, 0.5),
-        }
-      },
-    },
-  },
-}
-// </block:options>
-
-// <block:config:0>
 const config = {
   type: 'bar',
   data,
-  options,
+  options: {
+    elements: {
+      bar: {
+        borderWidth: 2,
+      },
+    },
+    hover: {
+      mode: 'nearest',
+      intersect: true,
+    },
+    plugins: {
+      autocolors: {
+        mode: 'dataset',
+        customize(context) {
+          const colors = context.colors
+          return {
+            background: lighten(colors.background, 0.5),
+            border: lighten(colors.border, 0.5),
+          }
+        },
+      },
+    },
+  },
 }
 // </block:config>
 

--- a/src/content/docs/samples/offset.md
+++ b/src/content/docs/samples/offset.md
@@ -4,47 +4,53 @@ description: Offset the color generation by a number of colors.
 ---
 
 Use `offset` so multiple charts on the same page, each with their own autocolors instance, don't all start
-from the same first color. Try the control below to switch the offset on the live chart.
+from the same first color. The three charts below share the exact same data — only their `offset` differs —
+so each one's palette starts one color further along than the last.
 
 ```js chart-editor
 // <block:data:1>
 const labels = ['Color']
-const datasets = []
+const values = []
 for (let i = 1; i <= 24; i++) {
-  datasets.push({
-    label: `Bar ${i}`,
-    data: [Utils.rand()],
-  })
+  values.push(Utils.rand())
 }
-const data = { labels, datasets }
 // </block:data>
 
 // <block:config:0>
-const config = {
-  type: 'bar',
-  data,
-  options: {
-    elements: {
-      bar: {
-        borderWidth: 2,
+function makeConfig(offset) {
+  const datasets = values.map((value, i) => ({
+    label: `Bar ${i + 1}`,
+    data: [value],
+  }))
+  return {
+    type: 'bar',
+    data: { labels, datasets },
+    options: {
+      elements: {
+        bar: {
+          borderWidth: 2,
+        },
+      },
+      hover: {
+        mode: 'nearest',
+        intersect: true,
+      },
+      plugins: {
+        autocolors: {
+          offset,
+        },
+        legend: false,
       },
     },
-    hover: {
-      mode: 'nearest',
-      intersect: true,
-    },
-    plugins: {
-      autocolors: {
-        offset: 0,
-      },
-      legend: false,
-    },
-  },
+  }
 }
 // </block:config>
 
 module.exports = {
-  config,
-  choices: [{ path: 'options.plugins.autocolors.offset', values: [0, 1, 2], control: 'radio' }],
+  charts: [
+    { title: 'offset: 0', config: makeConfig(0) },
+    { title: 'offset: 1', config: makeConfig(1) },
+    { title: 'offset: 2', config: makeConfig(2) },
+  ],
 }
 ```

--- a/src/content/docs/samples/offset.md
+++ b/src/content/docs/samples/offset.md
@@ -4,7 +4,7 @@ description: Offset the color generation by a number of colors.
 ---
 
 Use `offset` so multiple charts on the same page, each with their own autocolors instance, don't all start
-from the same first color. Use the buttons below to switch the offset on the live chart.
+from the same first color. Try the control below to switch the offset on the live chart.
 
 ```js chart-editor
 // <block:data:1>
@@ -38,29 +38,13 @@ const config = {
         offset: 0,
       },
       legend: false,
-      title: {
-        display: true,
-        text: 'offset: 0',
-      },
     },
   },
 }
 // </block:config>
 
-function setOffset(chart, offset) {
-  chart.options.plugins.autocolors.offset = offset
-  chart.options.plugins.title.text = `offset: ${offset}`
-  chart.update()
-}
-
-const actions = [
-  { name: 'Offset: 0', handler: (chart) => setOffset(chart, 0) },
-  { name: 'Offset: 1', handler: (chart) => setOffset(chart, 1) },
-  { name: 'Offset: 2', handler: (chart) => setOffset(chart, 2) },
-]
-
 module.exports = {
-  actions,
   config,
+  choices: [{ path: 'options.plugins.autocolors.offset', values: [0, 1, 2], control: 'radio' }],
 }
 ```


### PR DESCRIPTION
## Summary

- Bump `@kurkle/astro-chartjs-editor` devDependency `^1.0.0` → `^1.3.1` (resolves to `1.3.1`, confirmed via `npm ls`).
- `customize.md`: inline the separate `options` block into `config`, so the default `config` tab shows the whole sample instead of three lines of glue plus an extra tab.
- `offset.md`: rebuilt as three side-by-side `charts` variants (`offset: 0` / `1` / `2`), each built by a `makeConfig(offset)` factory that creates its own fresh dataset objects. All three variants use the exact same underlying data values (generated once), so the only difference between them is color assignment. See "Offset — why `choices` was replaced with `charts`" below for why this isn't a `choices` control.
- `docs/styles/starlight.css`: added to the existing `:root` block (heading scale) and added a new `.content-panel` rule, per the fleet convention of never replacing this file's existing rules.
- `bar.md` / `update.md`: checked, no changes. Neither fence has a `title=` attribute duplicating the page h1. `update.md`'s "Add data" action is a real action (pushes new data points) and stays as-is.
- `repeat.md`: **left unchanged** — see "Repeat — left alone" below.

## Verification

- `npm ls @kurkle/astro-chartjs-editor` → `chartjs-plugin-autocolors@0.0.0-development` → `@kurkle/astro-chartjs-editor@1.3.1`.
- `rm -rf node_modules/.astro` once before the first build (pre-1.3.1 cache had no version stamp), then `npm run docs` built cleanly (9 pages generated, no errors) on every iteration.
- Served the real build with `astro preview` and drove it with Playwright at 1400×900 and 1200-wide. Every changed page rendered non-blank charts, measured by counting non-transparent canvas pixels:
  - bar: 85 794 px (1400w) / 37 064 px (1200w)
  - customize: 72 886 / 45 912
  - offset (3 charts total): 56 715 / 148 695 (bigger at 1200w because the 2-column grid at 1400w becomes a 1-column stack of larger charts at 1200w — confirmed by screenshot, not a bug)
  - repeat (unchanged): 74 635 / 39 368
  - update: 374 532 / 190 116
- `customize.md` code panel now shows exactly 2 tabs (`config`, `data`) instead of 3 — confirmed by screenshot.
- `npm run lint` and `npm test` (fixture tests + `kurkle-check-package`, 14 tests / 19 package checks) pass. The pre-commit hook additionally ran typecheck/build/docs, all green, on both commits.

## Offset — why `choices` was replaced with `charts`

The first version of this PR gave `offset.md` a `choices` radio. It updated the live option value and its on-page readout, but never actually recolored the bars — I measured this with MD5 hashes of canvas-only screenshots (identical across offset 0/1/2 after full animation settle) and with a diagnostic action that read `chart.data.datasets[i].backgroundColor` straight off the live chart (also identical). Root cause: `chartjs-plugin-autocolors`'s default `'dataset'` mode only assigns a color once per dataset object (`dataset.backgroundColor = dataset.backgroundColor || background`), and the editor's `choices` mechanism only clones config containers along the *changed* path — since `offset` lives under `options`, `config.data` (and every dataset object in it) is reused by reference across the rebuild, so the already-colored objects never get touched again. This was **not a regression**: the pre-existing buttons had the identical limitation (verified — clicking through the old `Offset: 0/1/2` buttons only ever changed the `plugins.title` text; bars were pixel-identical before and after on `main`).

Per the coordinator's direction, `offset.md` now uses `charts` instead: three fixed variants (`offset: 0`, `1`, `2`), each produced by `makeConfig(offset)`, which builds its own `datasets` array from a shared `values` array on every call. Because each variant gets brand-new dataset objects, autocolors colors each one independently — no shared, already-colored objects to get stuck.

**Measured proof it works**, by sampling each chart's rendered bar colors directly off its canvas (Playwright + `getImageData`, run left-to-right at the row with the most distinct color runs):

- The three canvases are pairwise different: canvas MD5s `f7ab53b8…`, `51345668…`, `e6610aa3…` — all distinct.
- Comparing bar colors position-by-position between `offset: 0` and `offset: 1` directly (no shift): **0/23 bars match** — every single bar's color changed.
- Comparing `offset: 0`'s bar *N+1* to `offset: 1`'s bar *N* (i.e. "shifted by one color"): **21/22 match** (95%).
- Comparing `offset: 1`'s bar *N+1* to `offset: 2`'s bar *N*: **21/22 match** (95%).
- Example (first 3 bars, RGB): `offset: 0` → `202,81,81` / `128,52,52` / `52,128,128`; `offset: 1` → `128,50,50` / `82,203,203` / `143,203,82`; note `offset:1`'s bar 1 ≈ `offset:0`'s bar 2, confirming the one-step shift.
- Total non-transparent pixel count (a proxy for total bar area/height) is **identical across all three charts at a given width** — confirms the underlying data values are unchanged and only color differs, as intended.

This is exactly what the sample's prose now describes: three charts sharing the same data, each with its own autocolors instance whose palette starts one color further along.

## Repeat — left alone

I did not apply the analogous `choices` conversion to `repeat.md`, because that sample is different from `offset.md`: its existing "edit `repeat` in the code panel and click Run" workflow **actually works**. I verified this directly — editing `repeat: 3` → `1` in the live code editor and clicking Run re-executes the whole script, producing fresh dataset objects and a genuinely different, correctly-recolored chart (confirmed by canvas screenshot: distinct per-bar coloring before/after, matching a real repeat-of-1 pattern). A `choices` control there would hit the exact same stale-object issue diagnosed above and would be a real regression — replacing a working interaction with a non-working one. `repeat.md` is left exactly as it is on `main`, pending a decision on how (or whether) to work around the underlying editor/plugin interaction for that sample too.

Separately, while diagnosing this I found what looks like an unrelated one-line typo in `src/index.js`'s `setColors()`: for `mode: 'data'` it sets `dataset.border = border` instead of `dataset.borderColor = border`, so per-datapoint border colors are silently dropped. **Not fixed here** — confirmed with the coordinator this is a `fix:`-type change to published plugin source that needs its own PR and test, after this one lands.

## Test plan

- [x] `npm ls @kurkle/astro-chartjs-editor` resolves to `1.3.1`
- [x] `npm run docs` builds without errors (both commits)
- [x] All 5 sample pages render non-blank charts at 1400w and 1200w (measured ink pixel counts above)
- [x] `customize.md` shows 2 tabs instead of 3
- [x] `offset.md`'s three charts are pairwise distinct and each one's palette is the previous one shifted by one color (measured, numbers above)
- [x] `repeat.md` unchanged from `main` (confirmed via `git diff` and the GitHub compare API)
- [x] `npm run lint` passes (pre-existing warnings only, unchanged from `main`)
- [x] `npm test` passes (14 fixture tests, 19 package checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)